### PR TITLE
Ensure exposed API is safe

### DIFF
--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -85,7 +85,9 @@ impl Permutation {
 
         copy.sort();
         for i in copy.into_iter().enumerate() {
-            assert_eq!(i.0, i.1)
+            if i.0 != i.1 {
+                panic!("Invalid Representation");
+            }
         }
 
         perm
@@ -219,6 +221,19 @@ impl From<Vec<usize>> for Permutation {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    #[should_panic]
+    fn invalid_missing_0() {
+        Permutation::from_vec(vec![1, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_double_value() {
+        Permutation::from_vec(vec![0, 1, 2, 2]);
+    }
+
     use super::Permutation;
     #[test]
     fn id_perm() {


### PR DESCRIPTION
This pull request fixes the fact that, if debug assertions are off, some permutations could be created with invalid vec representation e.g. from a vector like [1,2,3] which has no 0. This way we have an internal fast implementation (the unchecked one) to be used in multiplication and an external checked one so that we cannot silently create invalid permutations. 