### PR TITLE
Run GAP tests in GAP with -r

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 cargo test --release -q
 
 ( for i in gap-code/tst/*.tst; do
-        echo gap -q -c "'QUIT_GAP(Test(\"$i\"));'"
+        echo gap -A -q -c "'QUIT_GAP(Test(\"$i\"));'"
     done ) | parallel --progress
 
 echo "Tests all passed!"


### PR DESCRIPTION
> The option `-r` tells GAP to ignore any user specific configuration files.

My `GAP.ini` loads the Semigroups package by default, but not polycyclic. This causes a bit of a problem with the tests. When the tests are run, quickcheck is loaded, which loads polycyclic, which gives warnings about methods matching more than one declaration (warnings which I'm trying to get rid of, see e.g. https://github.com/gap-system/gap/pull/4329). But these warnings aren't expected, and these diffs make it appear on first glance as if the vole tests haven't worked properly.

I think it's just best if the tests ignore any user configurations. In this case, it will mean that Semigroups doesn't get loaded (but polycyclic does).