### PR TITLE
Fix bug in `_Vole.processConstraints`

### DIFF
--- a/gap/internal/util.g
+++ b/gap/internal/util.g
@@ -125,7 +125,7 @@ _Vole.processConstraints := function(constraints)
             constraints[i] := VoleCon.LargestMovedPoint(constraints[i]);
         fi;
     od;
-    return constraints;
+    return Flat(constraints);
 end;
 
 # For some wrapper functions, we are explicitly asking for a subgroup of

--- a/tst/interface.tst
+++ b/tst/interface.tst
@@ -18,6 +18,10 @@ gap> VoleFind.Coset();
 Error, VoleFind.Coset: At least one argument must be given
 gap> VoleFind.Coset(fail);
 fail
+gap> VoleFind.Coset(Group([(1,2)(3,4), (1,3)(2,4)]) * (1,2,3));
+RightCoset(Group([ (1,2)(3,4), (1,3)(2,4) ]),(1,2,3))
+gap> VoleFind.Coset(Group([(1,2)]) * (2,3));
+RightCoset(Group([ (1,2) ]),(2,3))
 
 # VoleFind.Canonical
 gap> VoleFind.Canonical();


### PR DESCRIPTION
It is not guaranteed that the `VoleCon` functions only return a single constraint/refiner object; they could instead return a list thereof. Therefore, we should call `Flat` on the list of constraints AFTER processing them, as well as before.