### PR TITLE
Improve `VoleCon.InCoset` for symmetric group cosets 

### DIFF
--- a/gap/constraints.gi
+++ b/gap/constraints.gi
@@ -213,12 +213,21 @@ VoleCon.InCoset := function(U)
 end;
 
 VoleCon.InRightCoset := function(G, x)
+    local movedG, movedx, differ;
+
     if not IsPermGroup(G) then
         ErrorNoReturn("VoleCon.InRightCoset: ",
                       "The first argument must be a perm group");
     elif not IsPerm(x) then
         ErrorNoReturn("VoleCon.InRightCoset: ",
                       "The second argument must be a permutation");
+    elif IsNaturalSymmetricGroup(G) then
+        movedG := MovedPoints(G);  # is a GAP set
+        movedx := MovedPoints(x);
+        differ := Difference(movedx, movedG);
+        return [VoleCon.MovedPoints(Union(movedG, movedx)),
+                VoleCon.Transport(movedG, OnSets(movedG, x), OnSets),
+                VoleCon.Transport(differ, OnTuples(differ, x), OnTuples)];
     fi;
     return GB_Con.InCosetSimple(G, x);
 end;

--- a/tst/constraints.tst
+++ b/tst/constraints.tst
@@ -1,4 +1,4 @@
-#@local
+#@local n,Sn,pts,G,x
 gap> START_TEST("constraints.tst");
 gap> LoadPackage("vole", false);
 true
@@ -8,6 +8,17 @@ gap> VoleCon.Stabilise();
 Error, Function: number of arguments must be at least 1 (not 0)
 gap> VoleCon.Stabilise(1, 3);
 Error, VoleCon.Stabilize args: object[, action]
+
+# VoleCon.InCoset, for a coset of a symmetric group
+gap> n := 100;;
+gap> Sn := SymmetricGroup(n);;
+gap> VoleFind.Coset(Sn * Random(Sn)) = Sn * ();
+true
+gap> pts := OnSets([1 .. n], Random(SymmetricGroup(200)));;
+gap> G := SymmetricGroup(pts);;
+gap> x := Random(SymmetricGroup(200));;
+gap> VoleFind.Coset(G * x) = G * x;
+true
 
 #
 gap> STOP_TEST("constraints.tst");

--- a/tst/interface.tst
+++ b/tst/interface.tst
@@ -20,8 +20,8 @@ gap> VoleFind.Coset(fail);
 fail
 gap> VoleFind.Coset(Group([(1,2)(3,4), (1,3)(2,4)]) * (1,2,3));
 RightCoset(Group([ (1,2)(3,4), (1,3)(2,4) ]),(1,2,3))
-gap> VoleFind.Coset(Group([(1,2)]) * (2,3));
-RightCoset(Group([ (1,2) ]),(2,3))
+gap> VoleFind.Coset(Group([(1,2)]) * (2,3)) = Group([(1,2)]) * (2,3);
+true
 
 # VoleFind.Canonical
 gap> VoleFind.Canonical();


### PR DESCRIPTION
Instead of using the default refiner, which involves building a stabiliser chain for a symmetric group, we can refine for the same constraint with a combination of the moved points, a set transporter, and a tuple transporter.

This is now much faster for this special case. Compare the current master branch:
```
gap> VoleFind.Coset(SymmetricGroup(80) * (1,2,4));; time;
28201
```
with this PR:
```
gap> VoleFind.Coset(SymmetricGroup(80) * (1,2,4));; time;
9
```
Fixes #35.