### PR TITLE
Make the Rust refiner `SetTupleTransporter` be happy with empty sets and tuples

### DIFF
--- a/rust/src/vole/domain_state.rs
+++ b/rust/src/vole/domain_state.rs
@@ -86,7 +86,7 @@ impl DomainState {
         &self.digraph_stack
     }
 
-    pub fn refine_by_fact<T: Ord + Hash + Debug + QuickHashable>(&mut self, reason: T) -> trace::Result<()> {
+    pub fn add_invariant_fact<T: Ord + Hash + Debug + QuickHashable>(&mut self, reason: T) -> trace::Result<()> {
         self.tracer.add(trace::TraceEvent::Fact {
             reason: reason.quick_hash().0,
         })

--- a/rust/src/vole/refiners/simple.rs
+++ b/rust/src/vole/refiners/simple.rs
@@ -67,7 +67,7 @@ impl Refiner for SetTransporter {
             Side::Right => &self.set_right,
         };
 
-        state.refine_by_fact(set.len())?;
+        state.add_invariant_fact(set.len())?;
 
         state.base_refine_partition_by(|x| set.contains(x))?;
         Ok(())
@@ -162,7 +162,7 @@ impl Refiner for TupleTransporter {
             Side::Right => &self.tuplemap_right,
         };
 
-        state.refine_by_fact(match side {
+        state.add_invariant_fact(match side {
             Side::Left => self.tuple_left.len(),
             Side::Right => self.tuple_right.len(),
         })?;
@@ -246,7 +246,7 @@ impl Refiner for SetSetTransporter {
             Side::Right => &self.set_right,
         };
 
-        state.refine_by_fact(set.len())?;
+        state.add_invariant_fact(set.len())?;
 
         let base = state.partition().base_domain_size();
         let extended = state.partition().extended_domain_size();
@@ -339,7 +339,7 @@ impl Refiner for SetTupleTransporter {
             Side::Right => &self.set_right,
         };
 
-        state.refine_by_fact(set.len())?;
+        state.add_invariant_fact(set.len())?;
 
         let base = state.partition().base_domain_size();
         let extended = state.partition().extended_domain_size();

--- a/tst/settuplestab.tst
+++ b/tst/settuplestab.tst
@@ -8,4 +8,10 @@ gap> QC_Check([ QC_SetOf(QC_ListOf(IsPosInt)) ], {s} -> QuickChecker(Maximum(Fla
 true
 
 #
+gap> Vole.Stabiliser(SymmetricGroup(3), [], OnSetsTuples) = SymmetricGroup(3);
+true
+gap> Vole.Stabiliser(SymmetricGroup(3), [[]], OnSetsTuples) = SymmetricGroup(3);
+true
+
+#
 gap> STOP_TEST("settuplestab.tst");

--- a/tst/settupletrans.tst
+++ b/tst/settupletrans.tst
@@ -17,4 +17,10 @@ gap> QC_Check([ QC_SetOf(QC_ListOf(IsPosInt)), IsPermGroup ], function(s,g)
 true
 
 #
+gap> VoleFind.Rep(4, VoleRefiner.SetTupleTransporter([[]], []));
+fail
+gap> VoleFind.Rep(4, VoleRefiner.SetTupleTransporter([], [[]]));
+fail
+
+#
 gap> STOP_TEST("settupletrans.tst");


### PR DESCRIPTION
Hi @ChrisJefferson, this is my first time fiddling with Rust code, and in particular with the Rust parts of Vole, so I'd really appreciate you taking a look at this!

In particular, I'd like to know:
* is it safe to give the colour `0` to an extended vertex?
* is it correct to not call `refine_partition_cell_by` when we haven't actually changed anything? Are we missing out on any kind of 'tracing' because of skipping this call?

Resolves #40.