### PR TITLE
Make the Rust refiner `SetSetTransporter` be happy with empty sets and tuples

### DIFF
--- a/rust/src/vole/refiners/simple.rs
+++ b/rust/src/vole/refiners/simple.rs
@@ -231,6 +231,10 @@ impl Refiner for SetSetTransporter {
     }
 
     fn check(&self, p: &Permutation) -> bool {
+        if self.set_left.len() != self.set_right.len() {
+            return false;
+        }
+
         for set in &*self.set_left {
             let image: SortedVec<usize> = set.iter().map(|&x| p.apply(x)).collect();
             if !self.set_right.contains(&image) {
@@ -246,7 +250,13 @@ impl Refiner for SetSetTransporter {
             Side::Right => &self.set_right,
         };
 
+        // Record: number of sets in the set, whether set contains the empty set
         state.add_invariant_fact(set.len())?;
+        state.add_invariant_fact(set.iter().any(|x| x.len() == 0))?;        
+
+        if set.len() == 0 {
+            return Ok(());
+        }
 
         let base = state.partition().base_domain_size();
         let extended = state.partition().extended_domain_size();

--- a/tst/setsetstab.tst
+++ b/tst/setsetstab.tst
@@ -8,4 +8,16 @@ gap> QC_Check([ QC_SetOf(QC_SetOf(IsPosInt)) ], {s} -> QuickChecker(Maximum(Flat
 true
 
 #
+gap> Vole.Stabiliser(SymmetricGroup(3), [], OnSetsSets) = SymmetricGroup(3);
+true
+gap> Vole.Stabiliser(SymmetricGroup(3), [[]], OnSetsSets) = SymmetricGroup(3);
+true
+
+#
+gap> VoleFind.Rep(4, VoleRefiner.SetSetTransporter([[]], []));
+fail
+gap> VoleFind.Rep(4, VoleRefiner.SetSetTransporter([], [[]]));
+fail
+
+#
 gap> STOP_TEST("setsetstab.tst");


### PR DESCRIPTION
This is my currently-broken attempt at solving #45.