### PR TITLE
Improvement robustness of tests

### DIFF
--- a/tst/canonical-set.tst
+++ b/tst/canonical-set.tst
@@ -5,7 +5,7 @@ true
 
 #
 gap> QC_Check([IsPermGroup, QC_SetOf(IsPosInt)],
->    {g, s} -> VoleTestCanonical(Maximum([LargestMovedPoint(g), Maximum(s),2]), g, s, s -> VoleCon.Stabilize(s, OnSets), OnSets));
+>    {g, s} -> VoleTestCanonical(Maximum(Flat([LargestMovedPoint(g), s, 2])), g, s, s -> VoleCon.Stabilize(s, OnSets), OnSets));
 true
 
 #

--- a/tst/canonical-setset.tst
+++ b/tst/canonical-setset.tst
@@ -5,7 +5,7 @@ true
 
 #
 gap> QC_Check([IsPermGroup, QC_SetOf(QC_SetOf(IsPosInt))],
->    {g, s} -> VoleTestCanonical(Maximum([LargestMovedPoint(g), Maximum(Flat(s)),2]), g, s, x -> VoleCon.Stabilize(x, OnSetsSets), OnSetsSets));
+>    {g, s} -> VoleTestCanonical(Maximum(Flat([LargestMovedPoint(g), s, 2])), g, s, x -> VoleCon.Stabilize(x, OnSetsSets), OnSetsSets));
 true
 
 #

--- a/tst/setsetstab.tst
+++ b/tst/setsetstab.tst
@@ -4,7 +4,7 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_Check([ QC_SetOf(QC_SetOf(IsPosInt)) ], {s} -> QuickChecker(Maximum(Flat(s)), [VoleCon.Stabilize(s, OnSetsSets)]));
+gap> QC_Check([ QC_SetOf(QC_SetOf(IsPosInt)) ], {s} -> QuickChecker(Maximum(Flat([1,s])), [VoleCon.Stabilize(s, OnSetsSets)]));
 true
 
 #

--- a/tst/settuplestab.tst
+++ b/tst/settuplestab.tst
@@ -4,7 +4,7 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_Check([ QC_SetOf(QC_ListOf(IsPosInt)) ], {s} -> QuickChecker(Maximum(Flat(s)), [VoleCon.Stabilize(s, OnSetsTuples)]));
+gap> QC_Check([ QC_SetOf(QC_ListOf(IsPosInt)) ], {s} -> QuickChecker(Maximum(Flat([1,s])), [VoleCon.Stabilize(s, OnSetsTuples)]));
 true
 
 #


### PR DESCRIPTION
This is some preparatory work towards making sure that the Vole tests still work if https://github.com/ChrisJefferson/QuickCheck/pull/4 gets merged into QuickCheck.

In particular, that PR updates QuickCheck to sometimes randomly create empty lists and sets. We can't use `Maximum(list)` for an empty list or set `list`, so we have to make a few small changes.