### PR TITLE
Add 'refine by fact'

### DIFF
--- a/rust/src/vole/domain_state.rs
+++ b/rust/src/vole/domain_state.rs
@@ -86,6 +86,12 @@ impl DomainState {
         &self.digraph_stack
     }
 
+    pub fn refine_by_fact<T: Ord + Hash + Debug + QuickHashable>(&mut self, reason: T) -> trace::Result<()> {
+        self.tracer.add(trace::TraceEvent::Fact {
+            reason: reason.quick_hash().0,
+        })
+    }
+
     pub fn refine_partition_cell_by<F: Copy, T: Ord + Hash + Debug + QuickHashable>(
         &mut self,
         i: usize,

--- a/rust/src/vole/refiners/simple.rs
+++ b/rust/src/vole/refiners/simple.rs
@@ -67,6 +67,8 @@ impl Refiner for SetTransporter {
             Side::Right => &self.set_right,
         };
 
+        state.refine_by_fact(set.len())?;
+
         state.base_refine_partition_by(|x| set.contains(x))?;
         Ok(())
     }
@@ -159,6 +161,12 @@ impl Refiner for TupleTransporter {
             Side::Left => &self.tuplemap_left,
             Side::Right => &self.tuplemap_right,
         };
+
+        state.refine_by_fact(match side {
+            Side::Left => self.tuple_left.len(),
+            Side::Right => self.tuple_right.len(),
+        })?;
+
         state.base_refine_partition_by(|x| tuplemap.get(x).unwrap_or(&0))?;
         Ok(())
     }
@@ -237,6 +245,8 @@ impl Refiner for SetSetTransporter {
             Side::Left => &self.set_left,
             Side::Right => &self.set_right,
         };
+
+        state.refine_by_fact(set.len())?;
 
         let base = state.partition().base_domain_size();
         let extended = state.partition().extended_domain_size();
@@ -328,6 +338,8 @@ impl Refiner for SetTupleTransporter {
             Side::Left => &self.set_left,
             Side::Right => &self.set_right,
         };
+
+        state.refine_by_fact(set.len())?;
 
         let base = state.partition().base_domain_size();
         let extended = state.partition().extended_domain_size();

--- a/rust/src/vole/trace.rs
+++ b/rust/src/vole/trace.rs
@@ -23,6 +23,8 @@ pub enum TraceEvent {
     End(),
     EndRefine(),
     EndTrace(),
+    // This allows any value to be pushed onto the trace.
+    Fact { reason: QHash },
     NoSplit { cell: usize, reason: QHash },
 }
 


### PR DESCRIPTION
This adds a function 'refine_by_fact', which lets one (in practice) add any value to the trace.

Mathematically, this can be viewed as equivalent to pushing a graph with no edges, where every vertex as the some colour (although this function call, and such a graph, would produce different traces in practice, just from how it is implemented)