### PR TITLE
Explicitly translate a `points := k` option into a `VoleCon.LargestMovedPoint(k)` constraint

### DIFF
--- a/gap/internal/util.g
+++ b/gap/internal/util.g
@@ -101,6 +101,9 @@ end;
 _Vole.processConstraints := function(constraints, conf)
     local i;
     constraints := Flat(constraints);
+    if IsBound(conf.points) and IsInt(conf.points) then
+        Add(constraints, conf.points);
+    fi;
     for i in [1 .. Length(constraints)] do
         if IsPermGroup(constraints[i]) then
             constraints[i] := VoleCon.InGroup(constraints[i]);

--- a/tst/error.tst
+++ b/tst/error.tst
@@ -4,10 +4,10 @@ gap> LoadPackage("vole", false);
 true
 
 #
-gap> VoleFind.Rep(VoleRefiner.SetStab([3, 4, 5, [2, 3]]) : points := 7);
+gap> VoleFind.Rep([VoleRefiner.SetStab([3, 4, 5, [2, 3]]), 7]);
 Error, There was a fatal error in vole: Invalid problem specification. Does on\
 e of your constraints have the wrong argument type?
-gap> VoleFind.Group(VoleRefiner.SetSetStab([2, 3, 4]) : points := 7);
+gap> VoleFind.Group([VoleRefiner.SetSetStab([2, 3, 4]), 7]);
 Error, There was a fatal error in vole: Invalid problem specification. Does on\
 e of your constraints have the wrong argument type?
 

--- a/tst/grpconjtrans.tst
+++ b/tst/grpconjtrans.tst
@@ -10,7 +10,7 @@ gap> QC_Check([IsPermGroup, IsPermGroup], function(g, h)
 >      h2 := h^p;
 >      res := VoleFind.Rep(VoleCon.Transport(h,h2), BTKit_Con.InGroupSimple(g));
 >      if res = fail or h^res <> h2 then
->          return StringFormatted("Failure: {} {} {} {}", g,h,p,h2);
+>          return StringFormatted("Failure: {} {} {} {} {}", g,h,p,h2,res);
 >      fi;
 >      return true;
 >  end);

--- a/tst/setsetstab.tst
+++ b/tst/setsetstab.tst
@@ -19,5 +19,9 @@ fail
 gap> VoleFind.Rep(4, VoleRefiner.SetSetTransporter([], [[]]));
 fail
 
+# Issue #49
+gap> IsTrivial(VoleFind.Group(VoleCon.Stabilise([[]], OnSetsSets) : points := 1));
+true
+
 #
 gap> STOP_TEST("setsetstab.tst");


### PR DESCRIPTION
This requires the 'config' to be processed before the constraints.

This resolves #49.