### PR TITLE
Simplify/clean up test files

### DIFF
--- a/tst/canonical-grp-2.tst
+++ b/tst/canonical-grp-2.tst
@@ -5,12 +5,10 @@ true
 
 #
 gap> QC_Check([IsPermGroup, IsPermGroup, IsPermGroup],
-> function(g,s1,s2)
->   local lmp;
->   lmp := Maximum([LargestMovedPoint(g), LargestMovedPoint(s1), LargestMovedPoint(s2),2]);
->   return VoleTestCanonical(lmp, g, [s1,s2],
+> function(g, s1, s2)
+>   return VoleTestCanonical(g, [s1, s2],
 >     {x} -> [GB_Con.NormaliserSimple(x[1]), GB_Con.NormaliserSimple(x[2])],
->     {x,p} -> [x[1]^p, x[2]^p]);
+>     OnPairs);
 > end);
 true
 

--- a/tst/canonical-grp-3.tst
+++ b/tst/canonical-grp-3.tst
@@ -5,13 +5,7 @@ true
 
 #
 gap> QC_Check([IsPermGroup, IsPermGroup],
-> function(g,s)
->   local lmp;
->   lmp := Maximum(LargestMovedPoint(g), LargestMovedPoint(s), 2);
->   return VoleTestCanonical(lmp, g, s,
->     {x} -> [VoleCon.Stabilize(x)],
->     {x,p} -> x^p);
-> end);
+>     {g, s} -> VoleTestCanonical(g, s, VoleCon.Stabilize, OnPoints));
 true
 
 #

--- a/tst/canonical-grp-4.tst
+++ b/tst/canonical-grp-4.tst
@@ -4,14 +4,9 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_Check([IsPermGroup],
-> function(s)
->   local lmp;
->   lmp := Maximum( LargestMovedPoint(s), 2);
->   return VoleTestCanonical(lmp, SymmetricGroup(lmp), s,
->     {x} -> [VoleCon.Stabilize(x)],
->     {x,p} -> x^p);
-> end);
+gap> QC_Check([IsPermGroup], {s} ->
+>     VoleTestCanonical(
+>       SymmetricGroup(LargestMovedPoint(s)), s, VoleCon.Stabilize, OnPoints));
 true
 
 #

--- a/tst/canonical-grp.tst
+++ b/tst/canonical-grp.tst
@@ -5,11 +5,8 @@ true
 
 #
 gap> QC_Check([IsPermGroup, IsPermGroup],
-> function(g,s)
->   local lmp;
->   lmp := Maximum([LargestMovedPoint(g), LargestMovedPoint(s),2]);
->   return VoleTestCanonical(lmp, g, s, x -> GB_Con.NormaliserSimple(x), OnPoints);
-> end, rec(limit := 7));
+> {g, s} -> VoleTestCanonical(g, s, GB_Con.NormaliserSimple, OnPoints),
+> rec(limit := 7));
 true
 
 # This examples used to give a wrong result, caused by a problem where one

--- a/tst/canonical-set.tst
+++ b/tst/canonical-set.tst
@@ -5,7 +5,7 @@ true
 
 #
 gap> QC_Check([IsPermGroup, QC_SetOf(IsPosInt)],
->    {g, s} -> VoleTestCanonical(Maximum(Flat([LargestMovedPoint(g), s, 2])), g, s, s -> VoleCon.Stabilize(s, OnSets), OnSets));
+> {g, s} -> VoleTestCanonical(g, s, s -> VoleCon.Stabilize(s, OnSets), OnSets));
 true
 
 #

--- a/tst/canonical-setset.tst
+++ b/tst/canonical-setset.tst
@@ -5,7 +5,7 @@ true
 
 #
 gap> QC_Check([IsPermGroup, QC_SetOf(QC_SetOf(IsPosInt))],
->    {g, s} -> VoleTestCanonical(Maximum(Flat([LargestMovedPoint(g), s, 2])), g, s, x -> VoleCon.Stabilize(x, OnSetsSets), OnSetsSets));
+> {g, s} -> VoleTestCanonical(g, s, x -> VoleCon.Stabilize(x, OnSetsSets), OnSetsSets));
 true
 
 #

--- a/tst/constraints.tst
+++ b/tst/constraints.tst
@@ -1,4 +1,4 @@
-#@local n,Sn,pts,G,x,y,con,D
+#@local n, Sn, pts, G, x, y, con, D
 gap> START_TEST("constraints.tst");
 gap> LoadPackage("vole", false);
 true

--- a/tst/error.tst
+++ b/tst/error.tst
@@ -1,13 +1,13 @@
-#@local 
+#@local
 gap> START_TEST("error.tst");
 gap> LoadPackage("vole", false);
 true
 
 #
-gap> VoleFind.Rep(VoleRefiner.SetStab([3,4,5,[2,3]]) : points := 7);
+gap> VoleFind.Rep(VoleRefiner.SetStab([3, 4, 5, [2, 3]]) : points := 7);
 Error, There was a fatal error in vole: Invalid problem specification. Does on\
 e of your constraints have the wrong argument type?
-gap> VoleFind.Group(VoleRefiner.SetSetStab([2,3,4]) : points := 7);
+gap> VoleFind.Group(VoleRefiner.SetSetStab([2, 3, 4]) : points := 7);
 Error, There was a fatal error in vole: Invalid problem specification. Does on\
 e of your constraints have the wrong argument type?
 

--- a/tst/grpconjtrans.tst
+++ b/tst/grpconjtrans.tst
@@ -4,7 +4,7 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_Check([ IsPermGroup, IsPermGroup ], function(g,h)
+gap> QC_Check([IsPermGroup, IsPermGroup], function(g, h)
 >      local h2, res, p;
 >      p := Random(g);
 >      h2 := h^p;

--- a/tst/intersect-coset.tst
+++ b/tst/intersect-coset.tst
@@ -4,14 +4,11 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_CheckEqual([ IsPermGroup, IsPermGroup, IsPerm ],
-> function(s,t,p)
->  local lmp;
->  lmp := Maximum(LargestMovedPoint(s), LargestMovedPoint(t), LargestMovedPoint(p), 2);
->  return VoleFind.Coset([GB_Con.InCosetSimple(s,p), GB_Con.InCosetSimple(t,p)]);
->  end,
-> {s,t,p} -> RightCoset(Intersection(s,t),p) );
+# TODO: Add some tests of coset intersections that might be empty
+gap> QC_CheckEqual([IsPermGroup, IsPermGroup, IsPerm],
+> {s, t, p} -> VoleFind.Coset(GB_Con.InCosetSimple(s, p), GB_Con.InCosetSimple(t, p)),
+> {s, t, p} -> RightCoset(Intersection(s, t), p));
 true
 
 #
-gap> STOP_TEST("intersect.tst");
+gap> STOP_TEST("intersect-coset.tst");

--- a/tst/intersect-rbase.tst
+++ b/tst/intersect-rbase.tst
@@ -4,13 +4,9 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_CheckEqual([ IsPermGroup, IsPermGroup ],
-> function(s,t)
->  local lmp;
->  lmp := Maximum(LargestMovedPoint(s), LargestMovedPoint(t), 2);
->  return VoleFind.Group( [GB_Con.InGroup(s), GB_Con.InGroup(t)]);
->  end,
-> {s,t} -> Intersection(s,t) );
+gap> QC_CheckEqual([IsPermGroup, IsPermGroup],
+>     {s, t} -> VoleFind.Group(GB_Con.InGroup(s), GB_Con.InGroup(t)),
+>     Intersection);
 true
 
 #

--- a/tst/intersect.tst
+++ b/tst/intersect.tst
@@ -4,13 +4,9 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_CheckEqual([ IsPermGroup, IsPermGroup ],
-> function(s,t)
->  local lmp;
->  lmp := Maximum(LargestMovedPoint(s), LargestMovedPoint(t), 2);
->  return VoleFind.Group([GB_Con.InGroupSimple(s), GB_Con.InGroupSimple(t)]);
->  end,
-> {s,t} -> Intersection(s,t) );
+gap> QC_CheckEqual([IsPermGroup, IsPermGroup],
+>   {s, t} -> VoleFind.Group(GB_Con.InGroupSimple(s), GB_Con.InGroupSimple(t)),
+>   Intersection);
 true
 
 #

--- a/tst/multisetsetstab.tst
+++ b/tst/multisetsetstab.tst
@@ -4,8 +4,10 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_Check([ QC_SetOf(QC_SetOf(IsPosInt)),QC_SetOf(QC_SetOf(IsPosInt)),QC_SetOf(QC_SetOf(IsPosInt)) ],
->  {a,b,c} -> QuickChecker(Maximum(Flat([a,b,c,2])), [VoleCon.Stabilize(a, OnSetsSets),VoleCon.Stabilize(b, OnSetsSets), VoleCon.Stabilize(c, OnSetsSets)]));
+gap> QC_Check(List([1 .. 3], i -> QC_SetOf(QC_SetOf(IsPosInt))),
+> {a,b,c} -> QuickChecker(Maximum(Flat([a, b, c, 0])),
+>                         List([a, b, c], x -> VoleCon.Stabilize(x, OnSetsSets))
+> ));
 true
 
 #

--- a/tst/nothing-transport.tst
+++ b/tst/nothing-transport.tst
@@ -1,9 +1,11 @@
 #@local p
 gap> START_TEST("nothing-transport.tst");
 gap> LoadPackage("vole", false);;
-gap> VoleFind.Rep([BTKit_Con.Nothing()] : points := 6);
+
+#
+gap> VoleFind.Rep(BTKit_Con.Nothing() : points := 6);
 fail
-gap> VoleFind.Rep([BTKit_Con.Nothing2()] : points := 6);
+gap> VoleFind.Rep(BTKit_Con.Nothing2() : points := 6);
 fail
 
 #

--- a/tst/setsetstab.tst
+++ b/tst/setsetstab.tst
@@ -4,16 +4,16 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_Check([ QC_SetOf(QC_SetOf(IsPosInt)) ], {s} -> QuickChecker(Maximum(Flat([1,s])), [VoleCon.Stabilize(s, OnSetsSets)]));
+gap> QC_Check([QC_SetOf(QC_SetOf(IsPosInt))],
+> {s} -> QuickChecker(Maximum(Flat([0, s])), [VoleCon.Stabilize(s, OnSetsSets)])
+> );
 true
 
-#
+# Issue #45
 gap> Vole.Stabiliser(SymmetricGroup(3), [], OnSetsSets) = SymmetricGroup(3);
 true
 gap> Vole.Stabiliser(SymmetricGroup(3), [[]], OnSetsSets) = SymmetricGroup(3);
 true
-
-#
 gap> VoleFind.Rep(4, VoleRefiner.SetSetTransporter([[]], []));
 fail
 gap> VoleFind.Rep(4, VoleRefiner.SetSetTransporter([], [[]]));

--- a/tst/settuplestab.tst
+++ b/tst/settuplestab.tst
@@ -4,10 +4,12 @@ gap> ReadPackage("vole", "tst/test_functions.g");
 true
 
 #
-gap> QC_Check([ QC_SetOf(QC_ListOf(IsPosInt)) ], {s} -> QuickChecker(Maximum(Flat([1,s])), [VoleCon.Stabilize(s, OnSetsTuples)]));
+gap> QC_Check([QC_SetOf(QC_ListOf(IsPosInt))],
+> {s} -> QuickChecker(Maximum(Flat([0, s])), [VoleCon.Stabilize(s, OnSetsTuples)])
+> );
 true
 
-#
+# Issue #40
 gap> Vole.Stabiliser(SymmetricGroup(3), [], OnSetsTuples) = SymmetricGroup(3);
 true
 gap> Vole.Stabiliser(SymmetricGroup(3), [[]], OnSetsTuples) = SymmetricGroup(3);

--- a/tst/settupletrans-coset.tst
+++ b/tst/settupletrans-coset.tst
@@ -18,4 +18,4 @@ gap> QC_Check([ QC_SetOf(QC_ListOf(IsPosInt)), IsPermGroup ], function(s,g)
 true
 
 #
-gap> STOP_TEST("settupletrans.tst");
+gap> STOP_TEST("settupletrans-coset.tst");

--- a/tst/settupletrans.tst
+++ b/tst/settupletrans.tst
@@ -16,7 +16,7 @@ gap> QC_Check([ QC_SetOf(QC_ListOf(IsPosInt)), IsPermGroup ], function(s,g)
 >  end);
 true
 
-#
+# Issue #40
 gap> VoleFind.Rep(4, VoleRefiner.SetTupleTransporter([[]], []));
 fail
 gap> VoleFind.Rep(4, VoleRefiner.SetTupleTransporter([], [[]]));

--- a/tst/test_functions.g
+++ b/tst/test_functions.g
@@ -2,15 +2,15 @@ LoadPackage("vole", false);
 LoadPackage("quickcheck", false);
 LoadPackage("ferret", false);
 
-VoleTestCanonical := function(maxpnt, grp, obj, VoleFunc, action)
+VoleTestCanonical := function(grp, obj, VoleFunc, action)
     local p, newobj, ret, newret, image, newimage;
     p := Random(grp);
     newobj := action(obj, p);
-    ret := VoleFind.CanonicalPerm(grp, Flat([VoleFunc(obj)]) : points := maxpnt);
+    ret := VoleFind.CanonicalPerm(grp, Flat([VoleFunc(obj)]));
     if not(ret in grp) then
         return StringFormatted("A -Not in group! {} {} {}", grp, obj, ret);
     fi;
-    newret := VoleFind.CanonicalPerm(grp, Flat([VoleFunc(newobj)]) : points := maxpnt);
+    newret := VoleFind.CanonicalPerm(grp, Flat([VoleFunc(newobj)]));
     if not(newret in grp) then
         return StringFormatted("B - Not in group! {} {} {}", grp, obj, ret);
     fi;
@@ -97,15 +97,15 @@ function(p, l)
     return g;
 end;
 
-# Check (and simply benchmark) that VoleSolve(p,false,c) and GAPSolve(p,c) agree
+# Check (and simply benchmark) that VoleFind.Group(p,c) and GAPSolve(p,c) agree
 VoleBenchmark :=
 function(p, c)
     local ret1, ret2, time1, time2;
     time1 := NanosecondsSinceEpoch();
-    ret1 := VoleFind.Group(c : points := p);
+    ret1  := VoleFind.Group(p, c);
     time1 := NanosecondsSinceEpoch() - time1;
     time2 := NanosecondsSinceEpoch();
-    ret2 := GAPSolve(p, c);
+    ret2  := GAPSolve(p, c);
     time2 := NanosecondsSinceEpoch() - time2;
     if ret2 <> ret1 then
         Error(StringFormatted(Concatenation(

--- a/tst/two-closure.tst
+++ b/tst/two-closure.tst
@@ -1,10 +1,18 @@
+#@local g, gap, vole1, vole2, n
 gap> START_TEST("two-closure.tst");
 gap> LoadPackage("vole", false);
 true
-gap> pnts := 9;;
-gap> for g in AllTransitiveGroups(NrMovedPoints, pnts, Transitivity, 1) do
-> tc := TwoClosure(g);
-> orbs := OrbitalGraphs(g, pnts);
-> voletc := VoleFind.Group(pnts, VoleCon.Stabilize(orbs, OnTuplesDigraphs));
-> if tc <> voletc then Print(g, ":", tc, voletc); fi;
+
+#
+gap> n := 9;;
+gap> for g in AllTransitiveGroups(NrMovedPoints, n, Transitivity, 1) do
+>   gap := TwoClosure(g);
+>   vole1 := Vole.TwoClosure(g);
+>   vole2 := VoleFind.Group(n, VoleCon.Stabilize(OrbitalGraphs(g, n),
+>                                                OnTuplesDigraphs));
+>   if gap <> vole1 then Print(g, ":", gap, vole1); fi;
+>   if gap <> vole2 then Print(g, ":", gap, vole2); fi;
 > od;
+
+#
+gap> STOP_TEST("two-closure.tst");


### PR DESCRIPTION
* `VoleTestCanonical` doesn't need to take a largest moved point (since `VoleFind.CanonicalPerm` is good at working that out itself)
* This further prepares Vole for https://github.com/ChrisJefferson/QuickCheck/pull/4 being merged into QuickCheck.
* I fixed a few incorrect/outdated/inconsistent aspects of the test files, and made things a bit more readable.