### PR TITLE
CI: use `codecov/codecov-action@v2`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
       - name: "Run GAP tests for Vole"
         uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
       - name: "Setup tmate session"
         uses: mxschmitt/action-tmate@v3
         if: ${{ failure() }}


### PR DESCRIPTION
`codecov/codecov-action@v1` will stop working on 1st February, so if we still want code coverage, we'll need to move to `v2`. I'm not yet sure what that will entail, GAP has done it https://github.com/gap-system/gap/pull/4646 - let's just see if changing `1` to `2` does the trick.