### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,12 +23,13 @@ jobs:
       matrix:
         gap-branch:
           - master
+          - stable-4.14
           - stable-4.13
         rust-version:
           - stable
           #- 1.48
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Set up rust"
         uses: actions-rs/toolchain@v1
         with:
@@ -47,7 +48,9 @@ jobs:
       - name: "Run GAP tests for Vole"
         uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: "Setup tmate session"
         uses: mxschmitt/action-tmate@v3
         if: ${{ failure() }}

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -27,7 +27,7 @@ jobs:
       CHERE_INVOKING: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         #- name: "Set git to use UNIX-style line endings"
         #shell: bash
         #run: |
@@ -51,7 +51,9 @@ jobs:
       - name: "Run GAP tests for Vole"
         uses: gap-actions/run-pkg-tests@cygwin-v2
       - uses: gap-actions/process-coverage@cygwin-v2
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: "Setup tmate session"
         uses: mxschmitt/action-tmate@v3
         if: ${{ failure() }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,30 +15,27 @@ jobs:
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gap-actions/setup-gap@v2
         with:
           GAP_PKGS_TO_BUILD: ''
-      - name: 'Add a necessary symlink'
-        shell: bash
-        run: |
-          mkdir -p gaproot/pkg/
-          ln -f -s $PWD gaproot/pkg/
       - uses: gap-actions/build-pkg-docs@v1
         with:
           use-latex: 'true'
       - name: 'Upload PDF manual'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Vole manual (PDF)
           path: ./doc/manual.pdf
+          if-no-files-found: error
           retention-days: 3
       - name: 'Upload HTML manual'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Vole manual (HTML)
           path: |
             doc/*.html
             doc/*.css
             doc/*.js
+          if-no-files-found: error
           retention-days: 3


### PR DESCRIPTION
To keep code coverage working, you'll have to define a `CODECOV_TOKEN`.
This can be done once in the `peal` GitHub org for all repositories
in it at once.