### PR TITLE
Modernise the Cygwin CI setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Ubuntu
 
 on:
   workflow_dispatch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: Ubuntu
+name: CI
 
 on:
   workflow_dispatch:
@@ -14,11 +14,13 @@ on:
 
 jobs:
   test:
-    name: GAP ${{ matrix.gap-branch }} - Rust ${{matrix.rust-version}}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} - GAP ${{ matrix.gap-branch }} - Rust ${{matrix.rust-version}}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu
         gap-branch:
           - master
           - stable-4.15
@@ -26,9 +28,10 @@ jobs:
           - stable-4.13
         rust-version:
           - stable
-          #- 1.48
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: gap-actions/setup-cygwin@v2
+        if: ${{ runner.os == 'Windows' }}
       - name: "Set up rust"
         uses: actions-rs/toolchain@v1
         with:
@@ -45,7 +48,7 @@ jobs:
           GAP_PKGS_TO_CLONE: "OrbitalGraphs quickcheck"
           GAP_PKGS_TO_BUILD: "datastructures digraphs ferret io json orb profiling"
       - name: "Run GAP tests for Vole"
-        uses: gap-actions/run-pkg-tests@v2
+        uses: gap-actions/run-pkg-tests@v4
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,9 +8,13 @@ on:
     # Every weekday at 01:30 AM UTC
     - cron: '30 1 * * 1-5'
 
-#concurrency:
-#  group: ${{ github.workflow }}-${{ github.ref }}
-#  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+# the `concurrency` settings ensure that not too many CI jobs run in parallel
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   test:

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -13,27 +13,14 @@ on:
 jobs:
   # The Cygwin job
   cygwin:
-    name: Cygwin / GAP master
-    runs-on: windows-2022
+    name: Cygwin - GAP master - Rust stable
+    runs-on: windows-latest
     strategy:
       fail-fast: false
 
-    defaults:
-      run:
-        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
-
-    env:
-      CHERE_INVOKING: 1
-
     steps:
-      - uses: actions/checkout@v4
-        #- name: "Set git to use UNIX-style line endings"
-        #shell: bash
-        #run: |
-        #   git config --global core.autocrlf false
-        #   git config --global core.eol lf
-      - name: "Install Cygwin"
-        uses: gap-actions/setup-cygwin@v1
+      - uses: actions/checkout@v5
+      - uses: gap-actions/setup-cygwin@v2
       - name: "Set up rust"
         uses: actions-rs/toolchain@v1
         with:
@@ -43,13 +30,13 @@ jobs:
       - name: "Run the rust tests for Vole"
         run: cd rust && cargo test --release -q
       - name: "Clone GAP and some packages, and compile as necessary"
-        uses: gap-actions/setup-gap@cygwin-v2
+        uses: gap-actions/setup-gap@v2
         with:
           GAP_PKGS_TO_CLONE: "OrbitalGraphs quickcheck"
           GAP_PKGS_TO_BUILD: "datastructures digraphs ferret io json orb profiling"
       - name: "Run GAP tests for Vole"
-        uses: gap-actions/run-pkg-tests@cygwin-v2
-      - uses: gap-actions/process-coverage@cygwin-v2
+        uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -2,6 +2,9 @@ name: Windows
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
   schedule:
     # Every Monday at 2:30 AM UTC
     - cron: '30 2 * * 1'

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -5,6 +5,14 @@ on:
   push:
   pull_request:
 
+# the `concurrency` settings ensure that not too many CI jobs run in parallel
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   manual:
     name: Build manual


### PR DESCRIPTION
This changes the CI for the Cygwin job to be almost identical to the CI for the Ubuntu jobs. This is now possible because of some improvements to the `gap-actions/setup-cygwin` action and the rest of the `gap-actions` stuff.

I haven't actually merged the jobs, as I normally would and as I suggested in #82, because the Cygwin job is really slow (6 hours?), and so we don't want it to run whenever we run the Ubuntu jobs. So having it as a separate Workflow means that it can be triggered in different circumstances.

These circumstances now are manually, on schedule once a week, and I've newly added on pushes to `master`, which is something that I think we do infrequently enough that it's worth the cost.

I've run the Cygwin job on my fork, you can see it progressing at https://github.com/wilfwilson/vole/actions/workflows/cygwin.yml

Resolves #82.